### PR TITLE
Move nautical runtime files into nautical-base

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,16 @@ set(h_files
 
 add_library(nautical-base
     ${h_files}
+    "src/components/rendercomponent.cpp"
+    "src/engine.cpp"
     "src/gameobject.cpp"
+    "src/gameobject.cpp"
+    "src/graphics/shaderloader.cpp"
+    "src/graphics/textureloader.cpp"
+    "src/graphics/window.cpp"
+    "src/systems/input/keyboard.cpp"
+    "src/systems/renderer.cpp"
+    "src/util.cpp"
 )
 
 #####
@@ -80,7 +89,7 @@ if(SWIG_FOUND)
 		endif()
 	endmacro()
 
-	#add_swig_language(Lua FALSE)
+    add_swig_language(Lua FALSE)
 	#add_swig_language(Perl FALSE)
 	add_swig_language(Python TRUE)
 endif()
@@ -91,15 +100,6 @@ endif()
 add_executable(nautical
     ${h_files}
     "src/main.cpp"
-    "src/engine.cpp"
-    "src/gameobject.cpp"
-    "src/util.cpp"
-    "src/components/rendercomponent.cpp"
-    "src/graphics/shaderloader.cpp"
-    "src/graphics/textureloader.cpp"
-    "src/graphics/window.cpp"
-    "src/systems/input/keyboard.cpp"
-    "src/systems/renderer.cpp"
     ${nautical_bind_files}
 )
 
@@ -131,7 +131,7 @@ add_executable(nautical-tests
 target_include_directories(nautical-tests
     PUBLIC tests ${CUNIT_INCLUDE_DIRS}
 )
-target_link_libraries(nautical
+target_link_libraries(nautical-base
     ${GLEW_LIBRARIES}
     ${GLFW_LIBRARIES}
     ${FREEIMAGE_LIBRARIES}

--- a/bindings/lua/CMakeLists.txt
+++ b/bindings/lua/CMakeLists.txt
@@ -2,8 +2,18 @@ find_package(Lua REQUIRED)
 set_source_files_properties("nauticalua.i" PROPERTIES CPLUSPLUS TRUE)
 
 set(SWIG_MODULE_nauticalua_EXTRA_DEPS ${interface_files})
+include_directories(${LUA_INCLUDE_DIR})
+
+set(swig_runtime swigruntime.lua.h)
+add_custom_command(
+	OUTPUT ${swig_runtime}
+	COMMAND
+		${SWIG_EXECUTABLE} -Wall -c++ -lua -external-runtime ${swig_runtime}
+)
 
 SWIG_ADD_MODULE(nauticalua lua "nauticalua.i")
 SWIG_LINK_LIBRARIES(nauticalua ${LUA_LIBRARIES} nautical-base)
-include_directories(${LUA_INCLUDE_DIR})
 set_target_properties(${SWIG_MODULE_nauticalua_REAL_NAME} PROPERTIES PREFIX "")
+add_library(nsl_lua lualoader.cpp ${swig_runtime})
+target_link_libraries(nsl_lua ${LUA_LIBRARIES} nautical-base)
+target_include_directories(nsl_lua PUBLIC ${LUA_INCLUDE_DIR} ".")

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -17,7 +17,7 @@ set(swig_runtime swigruntime.py.h)
 add_custom_command(
 	OUTPUT ${swig_runtime}
 	COMMAND
-		${SWIG_EXECUTABLE} -Wall -c++ -python -external-runtime ${swig_runtime}
+	${SWIG_EXECUTABLE} -Wall -c++ -python -external-runtime ${swig_runtime}
 )
 
 

--- a/bindings/python/pythonloader.cpp
+++ b/bindings/python/pythonloader.cpp
@@ -46,7 +46,7 @@ namespace
         {
             auto type_info = SWIG_TypeQuery("nautical::GameObject *");
             auto pyObject = SWIG_NewPointerObj(gameObject, type_info, 0);
-            int ret = PyObject_SetAttrString(obj, "gameobject", pyObject);
+            PyObject_SetAttrString(obj, "gameobject", pyObject);
         }
         ~PythonScript()
         {

--- a/include/engine.h
+++ b/include/engine.h
@@ -11,6 +11,7 @@ namespace nautical
     namespace script
     {
         class ScriptFactory;
+		class ScriptLoader;
     }
 
     class Engine
@@ -32,6 +33,8 @@ namespace nautical
         void loadScript(std::string file);
 
         void addScript(std::string className, GameObject* gameObject);
+
+		void addScriptLoader(nautical::script::ScriptLoader*);
 
         inline systems::input::Keyboard* getKeyboard()
         {

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1,4 +1,4 @@
-#include "scripts/loaders.h"
+#include "scriptloader.h"
 #include "script.h"
 #include "engine.h"
 
@@ -100,9 +100,6 @@ void Engine::run()
         _keyboard->setKeyBinding(itr->name.GetString(), itr->value.GetInt());
     }
 
-#ifdef NAUTICAL_BIND_PYTHON
-    _factory->addLoader(new script::PythonScriptLoader);
-#endif
     _factory->load(nautical_config["script"]["file"].GetString());
     auto s = _factory->script(nautical_config["script"]["class"].GetString(),
                               &world);
@@ -123,6 +120,11 @@ void Engine::run()
 
         window.render();
     }
+}
+
+void Engine::addScriptLoader(nautical::script::ScriptLoader* loader)
+{
+	_factory->addLoader(loader);
 }
 
 std::string Engine::loadShader(std::string name, const char* vertLoc,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,9 @@ int main(int argc, char** argv)
     UNUSED argv;
 
     nautical::Engine engine = nautical::Engine();
+#ifdef NAUTICAL_BIND_PYTHON
+	engine.addScriptLoader(new nautical::script::PythonScriptLoader);
+#endif
 
     engine.run();
     return 0;


### PR DESCRIPTION
This was preventing Python (and presumably Lua) scripts from importing `nauticalpy`(/`nauticalua`)
